### PR TITLE
chore: defer TypeScript major upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,9 +32,12 @@ updates:
       - dependency-name: prettier
         versions:
           - ">=3.7.0 <4.0.0"
+      # Compiler majors require explicit migration and full compatibility review.
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
     open-pull-requests-limit: 3
-


### PR DESCRIPTION
## Summary

- defer automatic TypeScript major-version updates
- keep minor and patch updates available through the existing development dependency group
- require a dedicated migration and full compatibility review before moving beyond TypeScript 5

## 中文说明

- 暂缓 Dependabot 自动提交 TypeScript 编译器大版本更新
- 继续接收现有开发依赖分组中的小版本和补丁更新
- TypeScript 5 之后的大版本需要独立迁移，并完成 Windows、Ubuntu、Node.js 20/24 和类型行为验证

## Reason / 原因

Dependabot PR #14 upgraded directly from TypeScript 5.9 to 7.0 and failed all four CI platform jobs. Compiler majors can change configuration and type behavior, so they should not enter the stable branch as unattended dependency maintenance.

Dependabot PR #14 从 TypeScript 5.9 直接升级到 7.0，四组平台 CI 全部失败。编译器大版本可能改变配置和类型行为，因此不应作为无人审核的自动依赖更新进入稳定分支。